### PR TITLE
Fix signup profile loss, FX persistence, settle-up direct mode; harden security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "^18.3.1",
         "react-leaflet": "^4.2.1",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.9.5",
+        "react-router-dom": "^7.18.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "zod": "^4.4.3"
@@ -60,13 +60,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -85,21 +85,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -116,14 +116,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -133,14 +133,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -160,29 +160,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -232,27 +232,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -294,33 +294,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -328,14 +328,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1141,9 +1141,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
-      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -1155,9 +1155,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
-      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -1169,9 +1169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
-      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1183,9 +1183,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
-      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1197,9 +1197,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
-      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1211,9 +1211,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
-      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1225,9 +1225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
-      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1239,9 +1239,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
-      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -1253,9 +1253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
-      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -1267,9 +1267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
-      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1281,9 +1281,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
-      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -1295,9 +1309,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
-      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -1309,9 +1337,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
-      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -1323,9 +1351,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
-      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1337,9 +1365,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
-      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -1351,9 +1379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -1365,9 +1393,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
-      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -1378,10 +1406,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
-      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1393,9 +1435,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
-      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1407,9 +1449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
-      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1421,9 +1463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
-      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -1435,9 +1477,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
-      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -1904,9 +1946,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -2213,9 +2255,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2223,13 +2265,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2457,9 +2499,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2572,9 +2614,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2791,12 +2833,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -3324,9 +3370,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3631,10 +3677,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4307,9 +4363,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4949,9 +5005,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4968,9 +5024,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5147,9 +5203,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5207,9 +5263,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -5227,7 +5283,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5370,9 +5426,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.5.tgz",
-      "integrity": "sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5392,12 +5448,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.5.tgz",
-      "integrity": "sha512-mkEmq/K8tKN63Ae2M7Xgz3c9l9YNbY+NHH6NNeUmLA3kDkhKXRsNb/ZpxaEunvGo2/3YXdk5EJU3Hxp3ocaBPw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.5"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5510,13 +5566,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
-      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5526,28 +5582,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.5",
-        "@rollup/rollup-android-arm64": "4.52.5",
-        "@rollup/rollup-darwin-arm64": "4.52.5",
-        "@rollup/rollup-darwin-x64": "4.52.5",
-        "@rollup/rollup-freebsd-arm64": "4.52.5",
-        "@rollup/rollup-freebsd-x64": "4.52.5",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
-        "@rollup/rollup-linux-arm64-musl": "4.52.5",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-gnu": "4.52.5",
-        "@rollup/rollup-linux-x64-musl": "4.52.5",
-        "@rollup/rollup-openharmony-arm64": "4.52.5",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
-        "@rollup/rollup-win32-x64-gnu": "4.52.5",
-        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -5796,9 +5855,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6096,9 +6155,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6189,9 +6248,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6364,9 +6423,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.9.5",
+    "react-router-dom": "^7.18.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "zod": "^4.4.3"

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
+import { reportError } from '../lib/reportError'
+import { reconcilePendingSignup } from '../features/auth/lib/finalizeSignup'
 import { Button, Spinner } from './ui'
 
 type Status = 'idle' | 'processing' | 'error'
@@ -50,9 +52,50 @@ export function AuthCallback() {
 
     if (type === 'signup' && accessToken) {
       setStatus('processing')
-      // Email confirmation - redirect to dashboard
-      navigate('/', { replace: true })
-      return
+      // Email confirmation. A user who clicked the emailed magic link
+      // (instead of typing the 6-digit code into Signup's verify step)
+      // lands here signed in but WITHOUT Signup.tsx's finalizeAccount
+      // having run -- profile fields and invitation consumption would be
+      // silently dropped. Reconcile from the pending payload Signup stored
+      // in localStorage when it requested the OTP (no-op when absent or
+      // already finalized) before heading to the dashboard. Reconciliation
+      // failures are reported but never trap the user on this spinner --
+      // the trigger-populated metadata profile still exists either way.
+      let cancelled = false
+      // detectSessionInUrl may still be exchanging the hash for a session
+      // when this effect runs, so fall back to waiting (bounded) for the
+      // SIGNED_IN event before giving up on reconciliation.
+      const waitForUserId = async (): Promise<string | null> => {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (session?.user) return session.user.id
+        return new Promise((resolve) => {
+          // Timer created first (it can never fire before the next macrotask,
+          // so `subscription` below is always initialized when it runs).
+          const timer = setTimeout(() => {
+            subscription.unsubscribe()
+            resolve(null)
+          }, 5000)
+          const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => {
+            if (s?.user) {
+              clearTimeout(timer)
+              subscription.unsubscribe()
+              resolve(s.user.id)
+            }
+          })
+        })
+      }
+      void (async () => {
+        try {
+          const userId = await waitForUserId()
+          if (userId) await reconcilePendingSignup(userId)
+        } catch (err) {
+          reportError(err, 'auth-callback:reconcile-pending-signup')
+        }
+        if (!cancelled) navigate('/', { replace: true })
+      })()
+      return () => {
+        cancelled = true
+      }
     }
 
     // Hash present but not a recovery/signup callback. Only treat it as a

--- a/src/features/auth/Signup.tsx
+++ b/src/features/auth/Signup.tsx
@@ -15,6 +15,8 @@ import { type AvatarIconName } from '../../components/ui/Avatar'
 import { AvatarData, AnyAvatarData } from '../../types'
 import { AuthLayout } from './AuthLayout'
 import { validateEmail, validatePassword, validateRequired } from './lib/validation'
+import { finalizeSignup, storePendingSignup, clearPendingSignup } from './lib/finalizeSignup'
+import { reportError } from '../../lib/reportError'
 
 type Step = 'invitation' | 'details' | 'otp-verify' | 'welcome'
 type AccountMode = 'otp' | 'password'
@@ -152,6 +154,11 @@ export function Signup() {
   const [signupError, setSignupError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
+  // Set when the auth user exists but finalizeAccount failed (profile
+  // update / invitation consumption) -- drives the "Try again" button so
+  // the user is never silently advanced past a half-created account.
+  const [finalizeRetryUserId, setFinalizeRetryUserId] = useState<string | null>(null)
+
   // OTP verify step
   const [otpCode, setOtpCode] = useState('')
   const [otpError, setOtpError] = useState<string | null>(null)
@@ -252,16 +259,22 @@ export function Signup() {
     }
   }
 
-  /** Finish account creation once we have an authenticated user (either just signed up with password, or just verified an OTP). */
+  /**
+   * Finish account creation once we have an authenticated user (either just
+   * signed up with password, or just verified an OTP). Idempotent -- the
+   * "Try again" retry path re-runs it wholesale (the profile update just
+   * rewrites the same values; mark_invitation_used returning false on a
+   * retry means we already consumed it ourselves, treated as non-fatal by
+   * finalizeSignup).
+   */
   const finalizeAccount = async (userId: string) => {
     if (!invitation) return
 
     // Avatar system v2: mirrors ProfileModal.handleSubmit's branching. Photo
     // upload can only happen now (not in signUp's options.data) because it
     // needs the real userId for the storage path -- a failed upload must
-    // not block account creation, so it's caught and logged rather than
-    // thrown, same as the other best-effort steps below (invitation mark,
-    // trip assignment).
+    // not block account creation, so it's caught and reported rather than
+    // thrown.
     const update: Record<string, unknown> = {
       first_name: firstName,
       last_name: lastName,
@@ -274,7 +287,7 @@ export function Signup() {
         update.avatar_url = publicUrl
         setSavedAvatarUrl(publicUrl)
       } catch (err) {
-        console.error('Avatar upload failed:', err)
+        reportError(err, 'signup:avatar-upload')
       }
     } else if (avatarTab === 'icons') {
       const iconData: AnyAvatarData = { type: 'icon', icon: iconChoice.icon, bgColor: iconChoice.bgColor }
@@ -287,30 +300,47 @@ export function Signup() {
       setSavedAvatarData(avatarData)
     }
 
-    const { error: profileError } = await supabase
-      .from('users')
-      .update(update)
-      .eq('id', userId)
-    if (profileError) console.error('Profile update error:', profileError)
-
-    const { data: invitationMarked, error: invitationError } = await supabase.rpc('mark_invitation_used', {
-      p_invitation_id: invitation.id,
-      p_user_id: userId,
+    const result = await finalizeSignup({
+      userId,
+      invitationId: invitation.id,
+      tripId: invitation.trip_id,
+      profileUpdate: update,
     })
-    if (invitationError || !invitationMarked) {
-      console.error('Invitation update error:', invitationError)
+
+    if (!result.ok) {
+      // Visible error + retry instead of silently advancing to welcome
+      // with a half-created account. The auth user already exists, so the
+      // retry only re-runs the finalize writes.
+      setFinalizeRetryUserId(userId)
+      const message = `${result.errors.join(' ')} Your account was created — tap Try again to finish setting it up.`
+      if (step === 'otp-verify') {
+        setOtpError(message)
+      } else {
+        setSignupError(message)
+      }
+      return
     }
 
-    if (invitation.trip_id) {
-      const { error: assignError } = await supabase.rpc('assign_user_to_trip', {
-        p_invitation_id: invitation.id,
-        p_user_id: userId,
-      })
-      if (assignError) console.error('Trip assignment error:', assignError)
-    }
-
+    setFinalizeRetryUserId(null)
+    clearPendingSignup()
     clearSignupDraft()
     setStep('welcome')
+  }
+
+  const handleRetryFinalize = async () => {
+    if (!finalizeRetryUserId) return
+    setSignupError(null)
+    setOtpError(null)
+    setLoading(true)
+    try {
+      await finalizeAccount(finalizeRetryUserId)
+    } catch {
+      const message = 'An unexpected error occurred. Please try again.'
+      if (step === 'otp-verify') setOtpError(message)
+      else setSignupError(message)
+    } finally {
+      setLoading(false)
+    }
   }
 
   /**
@@ -393,10 +423,28 @@ export function Signup() {
 
     setLoading(true)
     try {
-      const { error } = await requestSignupOtp(email)
+      // Same metadata as the password signUp path: the new-user trigger
+      // populates public.users from raw_user_meta_data, so an OTP-created
+      // account gets its name/avatar even if the client-side finalize step
+      // never runs (e.g. the user clicks the emailed magic link instead of
+      // typing the code -- see finalizeSignup.ts reconciliation).
+      const { error } = await requestSignupOtp(email, {
+        first_name: firstName,
+        last_name: lastName,
+        avatar_data: avatarMetadataForSignup(),
+      })
       if (error) {
         setSignupError(mapSignupError(error.message))
       } else {
+        if (invitation) {
+          storePendingSignup({
+            invitationId: invitation.id,
+            tripId: invitation.trip_id,
+            firstName,
+            lastName,
+            avatarData: (avatarMetadataForSignup() as AnyAvatarData | undefined) ?? null,
+          })
+        }
         setStep('otp-verify')
       }
     } catch {
@@ -411,6 +459,30 @@ export function Signup() {
     setOtpError(null)
     setLoading(true)
     try {
+      // Re-validate the invitation before creating the account: minutes may
+      // have passed since the invitation step, and another invitee could
+      // have consumed the same code in the meantime. Failing here (before
+      // verifyOtp) avoids creating an orphan auth user with no invitation.
+      const { data: revalidateData, error: revalidateError } = await supabase.rpc('validate_invitation_code', {
+        p_code: invitationCode.trim(),
+      })
+      const revalidated = Array.isArray(revalidateData) ? revalidateData[0] : revalidateData
+      if (revalidateError || !revalidated) {
+        setOtpError('Error checking your invitation. Please try again.')
+        return
+      }
+      if (!revalidated.is_valid) {
+        clearPendingSignup()
+        setOtpError(
+          revalidated.reason === 'already_used'
+            ? 'This invitation code has already been used by someone else. Ask your organizer for a new invitation.'
+            : revalidated.reason === 'expired'
+              ? 'This invitation code has expired. Ask your organizer for a new invitation.'
+              : 'This invitation code is no longer valid. Ask your organizer for a new invitation.'
+        )
+        return
+      }
+
       const { user, error } = await verifyEmailOtp(email, otpCode.trim())
       if (error) {
         setOtpError(error.message)
@@ -514,8 +586,13 @@ export function Signup() {
           <Card.Content>
             <form onSubmit={accountMode === 'otp' ? handleSendOtp : handlePasswordSignup} className="space-y-5" noValidate>
               {signupError && (
-                <div className="bg-danger-50 border border-danger-200 text-danger-800 rounded-[var(--radius-md)] p-3 text-sm">
-                  {signupError}
+                <div className="bg-danger-50 border border-danger-200 text-danger-800 rounded-[var(--radius-md)] p-3 text-sm space-y-2" role="alert">
+                  <p>{signupError}</p>
+                  {finalizeRetryUserId && (
+                    <Button type="button" variant="outline" size="sm" onClick={handleRetryFinalize} isLoading={loading}>
+                      Try again
+                    </Button>
+                  )}
                 </div>
               )}
 
@@ -703,8 +780,13 @@ export function Signup() {
           <Card.Content>
             <form onSubmit={handleVerifySignupOtp} className="space-y-4" noValidate>
               {otpError && (
-                <div className="bg-danger-50 border border-danger-200 text-danger-800 rounded-[var(--radius-md)] p-3 text-sm">
-                  {otpError}
+                <div className="bg-danger-50 border border-danger-200 text-danger-800 rounded-[var(--radius-md)] p-3 text-sm space-y-2" role="alert">
+                  <p>{otpError}</p>
+                  {finalizeRetryUserId && (
+                    <Button type="button" variant="outline" size="sm" onClick={handleRetryFinalize} isLoading={loading}>
+                      Try again
+                    </Button>
+                  )}
                 </div>
               )}
               <Input

--- a/src/features/auth/lib/finalizeSignup.test.ts
+++ b/src/features/auth/lib/finalizeSignup.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  finalizeSignup,
+  reconcilePendingSignup,
+  storePendingSignup,
+  readPendingSignup,
+  clearPendingSignup,
+  profileUpdateFromPending,
+  FinalizeClient,
+  PendingSignupPayload,
+} from './finalizeSignup'
+
+// reportError touches supabase + import.meta.env -- stub both modules out
+// so these tests exercise finalizeSignup's decision logic only (every test
+// injects its own FinalizeClient; the real supabase default is never used).
+vi.mock('../../../lib/supabase', () => ({ supabase: {} }))
+vi.mock('../../../lib/reportError', () => ({ reportError: vi.fn() }))
+
+// vitest runs in the node environment (see vitest.config.ts) which has no
+// localStorage -- back the pending-signup helpers with an in-memory stub.
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => void storage.set(key, value),
+  removeItem: (key: string) => void storage.delete(key),
+  clear: () => storage.clear(),
+})
+
+interface FakeClientOptions {
+  updateError?: { message: string } | null
+  existingFullName?: string | null
+  selectError?: { message: string } | null
+  markResult?: { data: unknown; error: { message: string } | null }
+  assignResult?: { data: unknown; error: { message: string } | null }
+}
+
+function makeClient(options: FakeClientOptions = {}) {
+  const calls: { updates: Record<string, unknown>[]; rpcs: { fn: string; args: Record<string, unknown> }[] } = {
+    updates: [],
+    rpcs: [],
+  }
+  const client: FinalizeClient = {
+    from: () => ({
+      update: (values: Record<string, unknown>) => ({
+        eq: () => {
+          calls.updates.push(values)
+          return Promise.resolve({ error: options.updateError ?? null })
+        },
+      }),
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: { full_name: options.existingFullName ?? null },
+              error: options.selectError ?? null,
+            }),
+        }),
+      }),
+    }),
+    rpc: (fn, args) => {
+      calls.rpcs.push({ fn, args })
+      if (fn === 'mark_invitation_used') {
+        return Promise.resolve(options.markResult ?? { data: true, error: null })
+      }
+      return Promise.resolve(options.assignResult ?? { data: null, error: null })
+    },
+  }
+  return { client, calls }
+}
+
+const INPUT = {
+  userId: 'user-1',
+  invitationId: 'inv-1',
+  tripId: 'trip-1',
+  profileUpdate: { first_name: 'Ada', last_name: 'Lovelace', full_name: 'Ada Lovelace' },
+}
+
+describe('finalizeSignup', () => {
+  it('runs all three steps and succeeds', async () => {
+    const { client, calls } = makeClient()
+    const result = await finalizeSignup(INPUT, client)
+    expect(result).toEqual({ ok: true, errors: [] })
+    expect(calls.updates).toEqual([INPUT.profileUpdate])
+    expect(calls.rpcs.map((c) => c.fn)).toEqual(['mark_invitation_used', 'assign_user_to_trip'])
+  })
+
+  it('skips trip assignment when the invitation has no trip', async () => {
+    const { client, calls } = makeClient()
+    const result = await finalizeSignup({ ...INPUT, tripId: null }, client)
+    expect(result.ok).toBe(true)
+    expect(calls.rpcs.map((c) => c.fn)).toEqual(['mark_invitation_used'])
+  })
+
+  it('fails when the profile update errors and no profile exists yet', async () => {
+    const { client } = makeClient({ updateError: { message: 'boom' }, existingFullName: null })
+    const result = await finalizeSignup(INPUT, client)
+    expect(result.ok).toBe(false)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatch(/profile/i)
+  })
+
+  it('tolerates a profile update error when the trigger already populated the row', async () => {
+    const { client } = makeClient({ updateError: { message: 'boom' }, existingFullName: 'Ada Lovelace' })
+    const result = await finalizeSignup(INPUT, client)
+    expect(result.ok).toBe(true)
+  })
+
+  it('fails when mark_invitation_used errors', async () => {
+    const { client } = makeClient({ markResult: { data: null, error: { message: 'rpc down' } } })
+    const result = await finalizeSignup(INPUT, client)
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/invitation/i)
+  })
+
+  it('treats mark_invitation_used returning false (already used) as non-fatal', async () => {
+    const { client, calls } = makeClient({ markResult: { data: false, error: null } })
+    const result = await finalizeSignup(INPUT, client)
+    expect(result.ok).toBe(true)
+    // Still proceeds to trip assignment.
+    expect(calls.rpcs.map((c) => c.fn)).toEqual(['mark_invitation_used', 'assign_user_to_trip'])
+  })
+
+  it('treats a trip assignment error as non-fatal', async () => {
+    const { client } = makeClient({ assignResult: { data: null, error: { message: 'nope' } } })
+    const result = await finalizeSignup(INPUT, client)
+    expect(result.ok).toBe(true)
+  })
+})
+
+const PENDING: PendingSignupPayload = {
+  invitationId: 'inv-1',
+  tripId: 'trip-1',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  avatarData: { type: 'icon', icon: 'mountain', bgColor: '#0ea5e9' },
+}
+
+describe('pending signup storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips a payload through localStorage', () => {
+    storePendingSignup(PENDING)
+    expect(readPendingSignup()).toEqual(PENDING)
+    clearPendingSignup()
+    expect(readPendingSignup()).toBeNull()
+  })
+
+  it('returns null for corrupt or missing payloads', () => {
+    expect(readPendingSignup()).toBeNull()
+    localStorage.setItem('trips:pending-signup', 'not-json')
+    expect(readPendingSignup()).toBeNull()
+    localStorage.setItem('trips:pending-signup', JSON.stringify({ firstName: 'Ada' }))
+    expect(readPendingSignup()).toBeNull()
+  })
+})
+
+describe('profileUpdateFromPending', () => {
+  it('builds the users-row update including avatar data', () => {
+    expect(profileUpdateFromPending(PENDING)).toEqual({
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      full_name: 'Ada Lovelace',
+      avatar_data: PENDING.avatarData,
+      avatar_url: null,
+    })
+  })
+
+  it('omits avatar fields when no avatar was chosen', () => {
+    expect(profileUpdateFromPending({ ...PENDING, avatarData: null })).toEqual({
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      full_name: 'Ada Lovelace',
+    })
+  })
+})
+
+describe('reconcilePendingSignup', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('does nothing without a stored payload', async () => {
+    const { client, calls } = makeClient()
+    expect(await reconcilePendingSignup('user-1', client)).toBe(false)
+    expect(calls.updates).toHaveLength(0)
+    expect(calls.rpcs).toHaveLength(0)
+  })
+
+  it('clears the payload without finalizing when the profile is already complete', async () => {
+    storePendingSignup(PENDING)
+    const { client, calls } = makeClient({ existingFullName: 'Ada Lovelace' })
+    expect(await reconcilePendingSignup('user-1', client)).toBe(false)
+    expect(readPendingSignup()).toBeNull()
+    expect(calls.rpcs).toHaveLength(0)
+  })
+
+  it('finalizes an unfinalized user and clears the payload on success', async () => {
+    storePendingSignup(PENDING)
+    const { client, calls } = makeClient({ existingFullName: null })
+    expect(await reconcilePendingSignup('user-1', client)).toBe(true)
+    expect(calls.updates).toEqual([profileUpdateFromPending(PENDING)])
+    expect(calls.rpcs.map((c) => c.fn)).toEqual(['mark_invitation_used', 'assign_user_to_trip'])
+    expect(readPendingSignup()).toBeNull()
+  })
+
+  it('keeps the payload when finalization fails so a later mount can retry', async () => {
+    storePendingSignup(PENDING)
+    const { client } = makeClient({
+      existingFullName: null,
+      updateError: { message: 'boom' },
+      markResult: { data: null, error: { message: 'rpc down' } },
+    })
+    expect(await reconcilePendingSignup('user-1', client)).toBe(false)
+    expect(readPendingSignup()).toEqual(PENDING)
+  })
+})

--- a/src/features/auth/lib/finalizeSignup.ts
+++ b/src/features/auth/lib/finalizeSignup.ts
@@ -1,0 +1,221 @@
+import { supabase } from '../../../lib/supabase'
+import { reportError } from '../../../lib/reportError'
+import { AnyAvatarData } from '../../../types'
+
+/**
+ * Shared post-auth signup finalization (2026-07 signup-flow bug sweep).
+ *
+ * Both signup paths -- the in-page OTP/password flow in Signup.tsx and the
+ * magic-link callback in AuthCallback.tsx (a user who clicks the emailed
+ * link instead of typing the 6-digit code lands there already signed in,
+ * having skipped Signup's own finalize step entirely) -- must run the same
+ * three writes after the auth user exists:
+ *
+ *   1. users profile update (name + avatar) -- idempotent, safe to re-run.
+ *   2. mark_invitation_used -- may return false if the invitation was
+ *      already consumed (including by this same user on a retry).
+ *   3. assign_user_to_trip -- only when the invitation targets a trip.
+ *
+ * Failures are never swallowed: every one is reported via reportError so
+ * telemetry fires, and profile/invitation failures are surfaced to the
+ * caller as `ok: false` so the UI can show a visible error with a retry
+ * instead of silently advancing (the original bug: all three steps
+ * console.error'd and continued, leaving accounts with null profiles and
+ * unconsumed invitations).
+ *
+ * The supabase client is injected (structurally typed below) so the
+ * decision logic is unit-testable without network -- see
+ * finalizeSignup.test.ts.
+ */
+
+/** Minimal structural slice of the supabase client this module needs. */
+export interface FinalizeClient {
+  from(table: 'users'): {
+    update(values: Record<string, unknown>): {
+      eq(column: 'id', value: string): PromiseLike<{ error: { message: string } | null }>
+    }
+    select(columns: 'full_name'): {
+      eq(column: 'id', value: string): {
+        maybeSingle(): PromiseLike<{ data: { full_name: string | null } | null; error: { message: string } | null }>
+      }
+    }
+  }
+  rpc(
+    fn: 'mark_invitation_used' | 'assign_user_to_trip',
+    args: Record<string, unknown>
+  ): PromiseLike<{ data: unknown; error: { message: string } | null }>
+}
+
+export interface FinalizeSignupInput {
+  userId: string
+  invitationId: string
+  tripId: string | null
+  /** Column values for the users-row profile update (name + avatar fields). */
+  profileUpdate: Record<string, unknown>
+}
+
+export interface FinalizeSignupResult {
+  /** False when a step the user must not silently lose (profile update or
+   * invitation consumption) failed -- the caller should show an error with
+   * a retry rather than advancing. */
+  ok: boolean
+  /** Human-readable messages for the failed fatal steps (empty when ok). */
+  errors: string[]
+}
+
+export async function finalizeSignup(
+  input: FinalizeSignupInput,
+  client: FinalizeClient = supabase as unknown as FinalizeClient
+): Promise<FinalizeSignupResult> {
+  const { userId, invitationId, tripId, profileUpdate } = input
+  const errors: string[] = []
+
+  // 1. Profile update. Idempotent, so a retry just rewrites the same
+  // values. If it fails but the row already has a full_name (populated by
+  // the new-user trigger from the auth signup metadata), tolerate it --
+  // the profile isn't actually lost.
+  const { error: profileError } = await client.from('users').update(profileUpdate).eq('id', userId)
+  if (profileError) {
+    reportError(profileError, 'signup:profile-update')
+    const { data: existing } = await client.from('users').select('full_name').eq('id', userId).maybeSingle()
+    if (!existing?.full_name) {
+      errors.push('We couldn’t save your profile.')
+    }
+  }
+
+  // 2. Consume the invitation. An RPC-level error is fatal (retryable);
+  // `false` means the invitation was already used -- on a retry that's this
+  // same user, and we can't distinguish who consumed it from the client, so
+  // it's reported as a non-fatal warning rather than blocking the account
+  // that already exists.
+  const { data: invitationMarked, error: invitationError } = await client.rpc('mark_invitation_used', {
+    p_invitation_id: invitationId,
+    p_user_id: userId,
+  })
+  if (invitationError) {
+    reportError(invitationError, 'signup:mark-invitation-used')
+    errors.push('We couldn’t register your invitation.')
+  } else if (!invitationMarked) {
+    reportError(new Error(`mark_invitation_used returned false for invitation ${invitationId}`), 'signup:invitation-already-used')
+  }
+
+  // 3. Trip assignment (best-effort: the account and invitation state are
+  // intact either way, and assign_user_to_trip is safe to re-run -- but
+  // never silent).
+  if (tripId) {
+    const { error: assignError } = await client.rpc('assign_user_to_trip', {
+      p_invitation_id: invitationId,
+      p_user_id: userId,
+    })
+    if (assignError) reportError(assignError, 'signup:assign-user-to-trip')
+  }
+
+  return { ok: errors.length === 0, errors }
+}
+
+/**
+ * Pending-signup payload persisted to localStorage when the OTP is
+ * requested, so a user who completes auth via the emailed magic link
+ * (bypassing Signup's in-page verify step) can still be finalized by
+ * reconcilePendingSignup below. The photo-avatar File is deliberately
+ * absent -- not serializable; those users keep the default avatar and can
+ * set a photo from their profile.
+ */
+export interface PendingSignupPayload {
+  invitationId: string
+  tripId: string | null
+  firstName: string
+  lastName: string
+  avatarData: AnyAvatarData | null
+}
+
+const PENDING_SIGNUP_KEY = 'trips:pending-signup'
+
+export function storePendingSignup(payload: PendingSignupPayload): void {
+  try {
+    localStorage.setItem(PENDING_SIGNUP_KEY, JSON.stringify(payload))
+  } catch {
+    // Quota/private-mode failures: the in-page flow still works without it.
+  }
+}
+
+export function readPendingSignup(): PendingSignupPayload | null {
+  try {
+    const raw = localStorage.getItem(PENDING_SIGNUP_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PendingSignupPayload>
+    if (typeof parsed.invitationId !== 'string' || typeof parsed.firstName !== 'string' || typeof parsed.lastName !== 'string') {
+      return null
+    }
+    return {
+      invitationId: parsed.invitationId,
+      tripId: typeof parsed.tripId === 'string' ? parsed.tripId : null,
+      firstName: parsed.firstName,
+      lastName: parsed.lastName,
+      avatarData: (parsed.avatarData as AnyAvatarData | undefined) ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function clearPendingSignup(): void {
+  try {
+    localStorage.removeItem(PENDING_SIGNUP_KEY)
+  } catch {
+    // Ignore -- worst case the payload lingers until the next reconcile.
+  }
+}
+
+/** Builds the users-row update for a stored pending payload (mirrors
+ * Signup.tsx's finalizeAccount shape, minus the photo branch). */
+export function profileUpdateFromPending(pending: PendingSignupPayload): Record<string, unknown> {
+  const update: Record<string, unknown> = {
+    first_name: pending.firstName,
+    last_name: pending.lastName,
+    full_name: `${pending.firstName} ${pending.lastName}`,
+  }
+  if (pending.avatarData) {
+    update.avatar_data = pending.avatarData
+    update.avatar_url = null
+  }
+  return update
+}
+
+/**
+ * Magic-link reconciliation: if a signed-in user has a stored pending
+ * signup payload and their users row was never finalized (null full_name),
+ * run the same finalize steps the in-page flow would have. Clears the
+ * stored payload on success so it can't replay. Returns true when a
+ * finalize actually ran and succeeded.
+ */
+export async function reconcilePendingSignup(
+  userId: string,
+  client: FinalizeClient = supabase as unknown as FinalizeClient
+): Promise<boolean> {
+  const pending = readPendingSignup()
+  if (!pending) return false
+
+  const { data: row, error: rowError } = await client.from('users').select('full_name').eq('id', userId).maybeSingle()
+  if (rowError) {
+    reportError(rowError, 'signup:reconcile-profile-check')
+    return false
+  }
+  if (row?.full_name) {
+    // Already finalized (e.g. the in-page verify completed) -- just clean up.
+    clearPendingSignup()
+    return false
+  }
+
+  const result = await finalizeSignup(
+    {
+      userId,
+      invitationId: pending.invitationId,
+      tripId: pending.tripId,
+      profileUpdate: profileUpdateFromPending(pending),
+    },
+    client
+  )
+  if (result.ok) clearPendingSignup()
+  return result.ok
+}

--- a/src/features/chat/lib/applyProposal.rollback.test.ts
+++ b/src/features/chat/lib/applyProposal.rollback.test.ts
@@ -1,0 +1,90 @@
+/**
+ * applyAction create_expense_draft rollback behavior: a splits-insert
+ * failure rolls back the just-created expense, and a rollback failure is
+ * surfaced via reportError (it used to be silently ignored, leaving an
+ * invisible orphaned expense corrupting zero-sum balances).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../lib/reportError', () => ({ reportError: vi.fn() }))
+
+const behaviors = new Map<string, { insertError?: { message: string }; deleteError?: { message: string }; insertReturns?: unknown }>()
+const calls: Array<{ table: string; op: string; payload?: unknown }> = []
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: (table: string) => {
+      const b = () => behaviors.get(table) ?? {}
+      return {
+        insert: (payload: unknown) => {
+          calls.push({ table, op: 'insert', payload })
+          const result = { data: null, error: b().insertError ?? null }
+          return {
+            then: (fn: (r: typeof result) => unknown) => Promise.resolve(result).then(fn),
+            select: () => ({
+              single: async () => ({ data: b().insertReturns ?? null, error: b().insertError ?? null }),
+            }),
+          }
+        },
+        delete: () => ({
+          eq: async () => {
+            calls.push({ table, op: 'delete' })
+            return { error: b().deleteError ?? null }
+          },
+        }),
+      }
+    },
+  },
+}))
+
+import { applyAction } from './applyProposal'
+import { reportError } from '../../../lib/reportError'
+import type { ProposedAction } from '../../../shared/contracts/aiProposal'
+
+const ctx = { tripId: 'trip-1', userId: 'alice', baseCurrency: 'GBP' }
+
+// Same currency as base so resolveExpenseFxFields short-circuits (no fetch).
+const action = {
+  type: 'create_expense_draft',
+  idempotency_key: 'k1',
+  description: 'Dinner',
+  amount: 100,
+  currency: 'GBP',
+  participant_ids: ['alice', 'bob'],
+} as unknown as ProposedAction
+
+beforeEach(() => {
+  behaviors.clear()
+  calls.length = 0
+  vi.mocked(reportError).mockClear()
+})
+
+describe('applyAction create_expense_draft rollback', () => {
+  it('rolls back the expense when splits insert fails and does NOT reportError when the rollback succeeds', async () => {
+    behaviors.set('expenses', { insertReturns: { id: 'exp-1' } })
+    behaviors.set('expense_splits', { insertError: { message: 'splits boom' } })
+
+    await expect(applyAction(action, ctx)).rejects.toThrow('splits boom')
+    expect(calls.some((c) => c.table === 'expenses' && c.op === 'delete')).toBe(true)
+    expect(reportError).not.toHaveBeenCalled()
+  })
+
+  it('reports the rollback failure via reportError instead of swallowing it', async () => {
+    behaviors.set('expenses', { insertReturns: { id: 'exp-1' }, deleteError: { message: 'rollback boom' } })
+    behaviors.set('expense_splits', { insertError: { message: 'splits boom' } })
+
+    await expect(applyAction(action, ctx)).rejects.toThrow('splits boom')
+    expect(reportError).toHaveBeenCalledWith({ message: 'rollback boom' }, 'applyProposal.create_expense_draft.rollback')
+  })
+
+  it('same-currency create persists null fx fields and equal splits (baseline)', async () => {
+    behaviors.set('expenses', { insertReturns: { id: 'exp-1' } })
+    const result = await applyAction(action, ctx)
+    expect(result).toEqual({ table: 'expenses', id: 'exp-1' })
+    const expenseInsert = calls.find((c) => c.table === 'expenses' && c.op === 'insert')?.payload as Record<string, unknown>
+    expect(expenseInsert.fx_rate).toBeNull()
+    const splitsInsert = calls.find((c) => c.table === 'expense_splits' && c.op === 'insert')?.payload as Array<Record<string, unknown>>
+    expect(splitsInsert).toHaveLength(2)
+    expect(splitsInsert[0].base_currency_amount).toBeNull()
+  })
+})

--- a/src/features/chat/lib/applyProposal.ts
+++ b/src/features/chat/lib/applyProposal.ts
@@ -1,5 +1,7 @@
 import { supabase } from '../../../lib/supabase'
 import { largestRemainderDistribute, toMinorUnits, fromMinorUnits } from '../../../lib/money'
+import { resolveExpenseFxFields, splitBaseCurrencyAmount } from '../../../lib/fx/resolveExpenseFxFields'
+import { reportError } from '../../../lib/reportError'
 import { ProposedActionSchema, type ProposedAction } from '../../../shared/contracts/aiProposal'
 import type { Json } from '../../../types/database.types'
 
@@ -354,6 +356,16 @@ export async function applyAction(action: ProposedAction, ctx: ApplyContext, ref
     case 'create_expense_draft': {
       const paidBy = action.paid_by ?? ctx.userId
       const participantIds = action.participant_ids?.length ? action.participant_ids : [paidBy]
+      const paymentDate = action.payment_date ?? new Date().toISOString().slice(0, 10)
+      // Foreign-currency proposals: best-effort auto FX rate so the created
+      // expense counts in balances (null fields when the fetch fails --
+      // balances flag the missing rate, same as the manual editor paths).
+      const fx = await resolveExpenseFxFields({
+        amountMajor: action.amount,
+        currency: action.currency,
+        baseCurrency: ctx.baseCurrency,
+        paymentDate,
+      })
       const { data: expense, error } = await supabase
         .from('expenses')
         .insert({
@@ -362,9 +374,13 @@ export async function applyAction(action: ProposedAction, ctx: ApplyContext, ref
           amount: action.amount,
           currency: action.currency,
           paid_by: paidBy,
-          payment_date: action.payment_date ?? new Date().toISOString().slice(0, 10),
+          payment_date: paymentDate,
           category: action.category ?? 'other',
           participant_ids: participantIds,
+          fx_rate: fx.fx_rate,
+          fx_rate_date: fx.fx_rate_date,
+          base_currency_amount: fx.base_currency_amount,
+          rate_source: fx.rate_source,
         })
         .select()
         .single()
@@ -378,11 +394,17 @@ export async function applyAction(action: ProposedAction, ctx: ApplyContext, ref
         user_id: userId,
         amount: fromMinorUnits(shares[i], action.currency),
         split_type: 'equal' as const,
+        base_currency_amount: splitBaseCurrencyAmount(fromMinorUnits(shares[i], action.currency), fx),
       }))
       const { error: splitsError } = await supabase.from('expense_splits').insert(splitRows)
       if (splitsError) {
         // Roll back the orphaned expense so a partial apply doesn't corrupt balances.
-        await supabase.from('expenses').delete().eq('id', expense.id)
+        const { error: rollbackError } = await supabase.from('expenses').delete().eq('id', expense.id)
+        if (rollbackError) {
+          // Rollback failure means an orphaned expense with no splits is now
+          // corrupting zero-sum -- surface it instead of swallowing it.
+          reportError(rollbackError, 'applyProposal.create_expense_draft.rollback')
+        }
         throw new Error(splitsError.message)
       }
       return { table: 'expenses', id: expense.id }

--- a/src/features/expenses/editor/ExpenseEditorWizard.tsx
+++ b/src/features/expenses/editor/ExpenseEditorWizard.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../lib/queries/useExpenses'
 import { useTimeline } from '../../../lib/queries/useTimeline'
 import { uploadReceipt, getReceiptUrl } from '../../../lib/receiptUpload'
+import { resolveExpenseFxFields, splitBaseCurrencyAmount } from '../../../lib/fx/resolveExpenseFxFields'
 import { generateLinkCode } from '../../../lib/receiptParsing'
 import { useTripActivityLog } from '../../organizer/lib/activity'
 import { useFormDraft, useUnsavedChangesGuard } from '../../../lib/forms'
@@ -235,8 +236,19 @@ export function ExpenseEditorWizard({
         receiptUrl = uploaded.path
       }
 
-      const fxRateOverride = draft.fxRateOverride ? parseFloat(draft.fxRateOverride) : null
-      const rateSource = fxRateOverride != null ? 'manual' : null
+      // Persist the FX rate the ReviewStep previewed (bug fix: the preview's
+      // auto-fetched rate lived only in ReviewStep local state, so fx_rate
+      // saved as null for foreign-currency expenses and computeBalances
+      // excluded them entirely). fetchRate's memory cache makes this an
+      // instant re-read of the rate the preview just fetched; on fetch
+      // failure the fields stay null (previous behavior, warning stays).
+      const fx = await resolveExpenseFxFields({
+        amountMajor,
+        currency: draft.currency,
+        baseCurrency: trip.base_currency,
+        paymentDate: draft.paymentDate,
+        manualRate: draft.fxRateOverride ? parseFloat(draft.fxRateOverride) || null : null,
+      })
 
       const splits = computeSplits({
         mode: draft.splitMode,
@@ -252,6 +264,7 @@ export function ExpenseEditorWizard({
         split_type: draft.splitMode === 'shares' ? 'shares' : draft.splitMode === 'percentage' ? 'percentage' : draft.splitMode === 'custom' ? 'custom' : 'equal',
         percentage: s.percentage,
         shares: s.shares,
+        base_currency_amount: splitBaseCurrencyAmount(s.amountMajor, fx),
       }))
 
       const expensePayload = {
@@ -264,8 +277,10 @@ export function ExpenseEditorWizard({
         paid_by: draft.paidBy,
         participant_ids: draft.participantIds,
         receipt_url: receiptUrl,
-        fx_rate: fxRateOverride,
-        rate_source: rateSource,
+        fx_rate: fx.fx_rate,
+        fx_rate_date: fx.fx_rate_date,
+        base_currency_amount: fx.base_currency_amount,
+        rate_source: fx.rate_source,
       }
 
       if (isEditMode && editingExpense) {
@@ -349,6 +364,17 @@ export function ExpenseEditorWizard({
         total_amount: li.total_amount,
       }))
 
+      // Same FX persistence as the regular save path -- itemized claims are
+      // converted via the expense's fx_rate at balance time, so a missing
+      // rate excludes the whole expense there too.
+      const fx = await resolveExpenseFxFields({
+        amountMajor: params.totalMajor,
+        currency: draft.currency,
+        baseCurrency: trip.base_currency,
+        paymentDate: draft.paymentDate,
+        manualRate: draft.fxRateOverride ? parseFloat(draft.fxRateOverride) || null : null,
+      })
+
       const itemizedExpensePayload = {
         description: draft.description.trim() || draft.vendorName || 'Itemized receipt',
         amount: params.totalMajor,
@@ -361,6 +387,10 @@ export function ExpenseEditorWizard({
         receipt_url: draft.receiptPath,
         ai_parsed: true,
         status: 'unallocated' as const,
+        fx_rate: fx.fx_rate,
+        fx_rate_date: fx.fx_rate_date,
+        base_currency_amount: fx.base_currency_amount,
+        rate_source: fx.rate_source,
       }
 
       if (isEditMode && editingExpense) {

--- a/src/features/expenses/quick-capture/QuickCaptureSheet.tsx
+++ b/src/features/expenses/quick-capture/QuickCaptureSheet.tsx
@@ -6,6 +6,7 @@ import { parseReceipt } from '../../../lib/receiptParsing'
 import { useCreateExpense } from '../../../lib/queries/useExpenses'
 import { useTripActivityLog } from '../../organizer/lib/activity'
 import { largestRemainderDistribute, toMinorUnits, fromMinorUnits } from '../../../lib/money'
+import { resolveExpenseFxFields, splitBaseCurrencyAmount } from '../../../lib/fx/resolveExpenseFxFields'
 import { ALL_CATEGORIES, categoryIcon, categoryLabel } from '../lib/categoryStyle'
 import { defaultTaggedParticipantIds } from '../lib/participantDefaults'
 import { ExpenseEditorWizard } from '../editor/ExpenseEditorWizard'
@@ -126,6 +127,16 @@ export function QuickCaptureSheet({ isOpen, onClose, trip, participants, allExpe
       const totalMinor = toMinorUnits(totalMajor, state.currency)
       const shares = largestRemainderDistribute(totalMinor, participantIds.map(() => 1))
 
+      // Foreign-currency receipts: persist an auto-fetched FX rate so the
+      // expense counts in balances (best-effort; null fields on failure --
+      // the balances screen flags the missing rate).
+      const fx = await resolveExpenseFxFields({
+        amountMajor: totalMajor,
+        currency: state.currency,
+        baseCurrency: trip.base_currency,
+        paymentDate: state.date,
+      })
+
       const created = await createExpense.mutateAsync({
         expense: {
           description: state.vendor || 'Receipt',
@@ -138,11 +149,16 @@ export function QuickCaptureSheet({ isOpen, onClose, trip, participants, allExpe
           participant_ids: participantIds,
           receipt_url: state.receiptPath,
           ai_parsed: !!state.parsed,
+          fx_rate: fx.fx_rate,
+          fx_rate_date: fx.fx_rate_date,
+          base_currency_amount: fx.base_currency_amount,
+          rate_source: fx.rate_source,
         },
         splits: participantIds.map((userId, i) => ({
           user_id: userId,
           amount: fromMinorUnits(shares[i], state.currency),
           split_type: 'equal' as const,
+          base_currency_amount: splitBaseCurrencyAmount(fromMinorUnits(shares[i], state.currency), fx),
         })),
       })
       logActivity({ verb: 'expense_added', entity: { type: 'expense', id: created.id, label: created.description } })

--- a/src/features/expenses/settle-up/settleUpLogic.test.ts
+++ b/src/features/expenses/settle-up/settleUpLogic.test.ts
@@ -137,6 +137,81 @@ describe('computeSuggestedPayments carryover exclusion guards', () => {
   })
 })
 
+describe('computeSuggestedPayments direct (simplify=false) mode', () => {
+  const threePeople: SettleUpPerson[] = [
+    { userId: 'alice', name: 'Alice' },
+    { userId: 'bob', name: 'Bob' },
+    { userId: 'charlie', name: 'Charlie' },
+  ]
+  // Chain: Bob owes Alice £30 (e1), Charlie owes Bob £30 (e2).
+  const chainExpenses = [
+    makeExpense({ id: 'e1', amount: 60, paid_by: 'alice', splits: [makeSplit('alice', 30), makeSplit('bob', 30)] }),
+    makeExpense({ id: 'e2', amount: 60, paid_by: 'bob', splits: [makeSplit('bob', 30), makeSplit('charlie', 30)] }),
+  ]
+
+  it('direct mode preserves actual pairwise debts instead of netting through third parties', () => {
+    const direct = computeSuggestedPayments(chainExpenses, [], threePeople, 'GBP', false)
+    expect(direct).toHaveLength(2)
+    expect(direct).toEqual(
+      expect.arrayContaining([
+        { from: 'bob', to: 'alice', fromName: 'Bob', toName: 'Alice', amount: 30 },
+        { from: 'charlie', to: 'bob', fromName: 'Charlie', toName: 'Bob', amount: 30 },
+      ])
+    )
+  })
+
+  it('simplify mode collapses the same chain into fewer payments (the toggle actually changes the plan)', () => {
+    const simplified = computeSuggestedPayments(chainExpenses, [], threePeople, 'GBP', true)
+    expect(simplified).toEqual([{ from: 'charlie', to: 'alice', fromName: 'Charlie', toName: 'Alice', amount: 30 }])
+  })
+
+  it('direct mode folds usable carryovers into the pairwise amounts', () => {
+    const expenses = [
+      makeExpense({ id: 'e1', amount: 100, paid_by: 'alice', splits: [makeSplit('alice', 50), makeSplit('bob', 50)] }),
+    ]
+    const carryovers = [makeCarryover({ from_user_id: 'bob', to_user_id: 'alice', amount: 30 })]
+    const direct = computeSuggestedPayments(expenses, [], people, 'GBP', false, carryovers)
+    expect(direct).toEqual([{ from: 'bob', to: 'alice', fromName: 'Bob', toName: 'Alice', amount: 80 }])
+  })
+
+  it('direct mode excludes mismatched-currency carryovers, same as simplify mode', () => {
+    const expenses = [
+      makeExpense({ id: 'e1', amount: 100, paid_by: 'alice', splits: [makeSplit('alice', 50), makeSplit('bob', 50)] }),
+    ]
+    const carryovers = [makeCarryover({ from_user_id: 'bob', to_user_id: 'alice', amount: 10000, currency: 'JPY' })]
+    const direct = computeSuggestedPayments(expenses, [], people, 'GBP', false, carryovers)
+    expect(direct).toEqual([{ from: 'bob', to: 'alice', fromName: 'Bob', toName: 'Alice', amount: 50 }])
+  })
+
+  it('direct mode emits no dust payments for a settled pair (epsilon behavior)', () => {
+    const expenses = [
+      makeExpense({ id: 'e1', amount: 60, paid_by: 'alice', splits: [makeSplit('alice', 30), makeSplit('bob', 30)] }),
+      makeExpense({ id: 'e2', amount: 60, paid_by: 'bob', splits: [makeSplit('alice', 30), makeSplit('bob', 30)] }),
+    ]
+    expect(computeSuggestedPayments(expenses, [], people, 'GBP', false)).toEqual([])
+  })
+
+  it('direct mode respects recorded settlements between a pair', () => {
+    const expenses = [
+      makeExpense({ id: 'e1', amount: 100, paid_by: 'alice', splits: [makeSplit('alice', 50), makeSplit('bob', 50)] }),
+    ]
+    const settlements = [
+      {
+        id: 's1',
+        trip_id: 'trip-1',
+        from_user_id: 'bob',
+        to_user_id: 'alice',
+        amount: 20,
+        currency: 'GBP',
+        status: 'confirmed',
+        created_at: '2026-08-02T00:00:00Z',
+      } as never,
+    ]
+    const direct = computeSuggestedPayments(expenses, settlements, people, 'GBP', false)
+    expect(direct).toEqual([{ from: 'bob', to: 'alice', fromName: 'Bob', toName: 'Alice', amount: 30 }])
+  })
+})
+
 describe('isFullySettled with folded settlement_carryovers', () => {
   it('a trip that looks settled on its own is NOT fully settled once an unpaid carryover is folded in', () => {
     const expenses = [

--- a/src/features/expenses/settle-up/settleUpLogic.ts
+++ b/src/features/expenses/settle-up/settleUpLogic.ts
@@ -13,7 +13,8 @@ import { fromMinorUnits } from '../../../lib/money'
 function balanceEpsilonMajor(currency: string): number {
   return fromMinorUnits(1, currency)
 }
-import { computeBalances } from '../lib/balances'
+import { computeBalances, carryoversToPseudoSettlements, partitionCarryovers } from '../lib/balances'
+import { computePairwiseBreakdown } from '../money-space/moneyPosition'
 import type { ExpenseWithDetails } from '../../../lib/queries/useExpenses'
 import type { Settlement, SettlementSnapshot, SettlementCarryover } from '../../../lib/queries/useSettlements'
 
@@ -62,18 +63,59 @@ export function computeSuggestedPayments(
   const epsilon = balanceEpsilonMajor(baseCurrency)
 
   if (!simplify) {
-    // Direct (non-minimized) pairing: still uses the same greedy algorithm
-    // since without simplification "direct" settlement in a group context
-    // has no single canonical definition beyond min-cash-flow itself in
-    // this app's model (no per-expense debtor/creditor pairing is tracked
-    // independently of the net balance) -- min-cash-flow is used as the
-    // baseline either way, with `simplify` primarily gating whether the UI
-    // presents it as "the" plan or an optional suggestion. This keeps the
-    // n-1 payments guarantee (plan §12) regardless of the toggle.
-    return minimizeTransactions(personInputs, epsilon)
+    // Direct (non-minimized) mode: pairwise who-owes-whom straight from the
+    // actual expense/settlement history, WITHOUT netting a debt through a
+    // third party (previously both branches called minimizeTransactions
+    // identically, making the simplify toggle a no-op). Reuses the exact
+    // pairwise ledger MoneySpace's per-person breakdown is built on
+    // (computePairwiseBreakdown), with usable carryovers folded in as
+    // pseudo-settlements via the SAME partitionCarryovers rules
+    // computeBalances applies, so figures stay in sync with the header.
+    return computeDirectPayments(expenses, settlements, people, baseCurrency, carryovers)
   }
 
   return minimizeTransactions(personInputs, epsilon)
+}
+
+/**
+ * Direct pairwise payments: for every participant, each counterparty they
+ * NET owe (per computePairwiseBreakdown's ledger over expenses +
+ * settlements) becomes one payment from them to that counterparty. Uses the
+ * same BALANCE_EPSILON_MINOR threshold as the breakdown (1 minor unit,
+ * matching balanceEpsilonMajor), so a settled pair never produces a
+ * dust-amount payment.
+ */
+function computeDirectPayments(
+  expenses: ExpenseWithDetails[],
+  settlements: Settlement[],
+  people: SettleUpPerson[],
+  baseCurrency: string,
+  carryovers: SettlementCarryover[]
+): Transaction[] {
+  const participantUserIds = people.map((p) => p.userId)
+  const { usable: usableCarryovers } = partitionCarryovers(carryovers, baseCurrency, participantUserIds)
+  const settlementsWithCarryovers =
+    usableCarryovers.length > 0 ? [...settlements, ...carryoversToPseudoSettlements(usableCarryovers)] : settlements
+
+  const nameOf = new Map(people.map((p) => [p.userId, p.name]))
+  const transactions: Transaction[] = []
+  for (const person of people) {
+    const rows = computePairwiseBreakdown(expenses, settlementsWithCarryovers, participantUserIds, person.userId, baseCurrency)
+    for (const row of rows) {
+      // Negative netMinor = this person owes that counterparty. Only the
+      // debtor side emits the payment, so each pair appears exactly once.
+      if (row.netMinor < 0) {
+        transactions.push({
+          from: person.userId,
+          to: row.userId,
+          fromName: nameOf.get(person.userId) ?? person.userId,
+          toName: nameOf.get(row.userId) ?? row.userId,
+          amount: fromMinorUnits(-row.netMinor, baseCurrency),
+        })
+      }
+    }
+  }
+  return transactions
 }
 
 export function getMyTransactions(allTransactions: Transaction[], userId: string) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -92,11 +92,16 @@ export function useAuth() {
    * OTP-first invitation signup: send a code to an email that does NOT
    * have an account yet (shouldCreateUser: true creates the auth user on
    * verify, without requiring a password).
+   *
+   * `metadata` (first_name/last_name/avatar_data) is passed through as
+   * `options.data` -- raw_user_meta_data consumed by the new-user trigger,
+   * mirroring the password `signUp` path above -- so an OTP signup never
+   * creates a bare auth user with an empty profile row.
    */
-  const requestSignupOtp = async (email: string) => {
+  const requestSignupOtp = async (email: string, metadata?: Record<string, unknown>) => {
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { shouldCreateUser: true },
+      options: { shouldCreateUser: true, data: metadata },
     })
     return { error }
   }

--- a/src/lib/fx/resolveExpenseFxFields.test.ts
+++ b/src/lib/fx/resolveExpenseFxFields.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolveExpenseFxFields, splitBaseCurrencyAmount } from './resolveExpenseFxFields'
+import { fetchRate } from './fetchRate'
+
+vi.mock('./fetchRate', () => ({ fetchRate: vi.fn() }))
+
+const mockedFetchRate = vi.mocked(fetchRate)
+
+beforeEach(() => {
+  mockedFetchRate.mockReset()
+})
+
+describe('resolveExpenseFxFields', () => {
+  it('same currency -> all-null fields, no fetch', async () => {
+    const fx = await resolveExpenseFxFields({ amountMajor: 100, currency: 'GBP', baseCurrency: 'GBP', paymentDate: '2026-07-01' })
+    expect(fx).toEqual({ fx_rate: null, fx_rate_date: null, base_currency_amount: null, rate_source: null })
+    expect(mockedFetchRate).not.toHaveBeenCalled()
+  })
+
+  it('manual override wins over any fetch and writes rate_source=manual + base_currency_amount', async () => {
+    const fx = await resolveExpenseFxFields({
+      amountMajor: 200,
+      currency: 'EUR',
+      baseCurrency: 'GBP',
+      paymentDate: '2026-07-01',
+      manualRate: 0.85,
+    })
+    expect(fx).toEqual({ fx_rate: 0.85, fx_rate_date: null, base_currency_amount: 170, rate_source: 'manual' })
+    expect(mockedFetchRate).not.toHaveBeenCalled()
+  })
+
+  it('persists an auto-fetched rate (fx_rate, fx_rate_date, base_currency_amount, rate_source)', async () => {
+    mockedFetchRate.mockResolvedValue({ rate: 0.0053, date: '2026-07-01', from: 'JPY', to: 'GBP', source: 'frankfurter' })
+    const fx = await resolveExpenseFxFields({
+      amountMajor: 10000,
+      currency: 'JPY',
+      baseCurrency: 'GBP',
+      paymentDate: '2026-07-01',
+      today: '2026-07-02',
+    })
+    expect(fx).toEqual({ fx_rate: 0.0053, fx_rate_date: '2026-07-01', base_currency_amount: 53, rate_source: 'frankfurter' })
+    expect(mockedFetchRate).toHaveBeenCalledWith('2026-07-01', 'JPY', 'GBP', '2026-07-02')
+  })
+
+  it('fetch returning null -> all-null fields (expense still saves, warning behavior stays)', async () => {
+    mockedFetchRate.mockResolvedValue(null)
+    const fx = await resolveExpenseFxFields({ amountMajor: 100, currency: 'EUR', baseCurrency: 'GBP', paymentDate: '2026-07-01' })
+    expect(fx).toEqual({ fx_rate: null, fx_rate_date: null, base_currency_amount: null, rate_source: null })
+  })
+
+  it('fetch throwing -> all-null fields, never throws', async () => {
+    mockedFetchRate.mockRejectedValue(new Error('network down'))
+    const fx = await resolveExpenseFxFields({ amountMajor: 100, currency: 'EUR', baseCurrency: 'GBP', paymentDate: '2026-07-01' })
+    expect(fx).toEqual({ fx_rate: null, fx_rate_date: null, base_currency_amount: null, rate_source: null })
+  })
+
+  it('zero/invalid manual rate falls through to auto fetch', async () => {
+    mockedFetchRate.mockResolvedValue({ rate: 1.2, date: '2026-07-01', from: 'EUR', to: 'GBP', source: 'db' })
+    const fx = await resolveExpenseFxFields({
+      amountMajor: 10,
+      currency: 'EUR',
+      baseCurrency: 'GBP',
+      paymentDate: '2026-07-01',
+      manualRate: 0,
+    })
+    expect(fx.rate_source).toBe('db')
+    expect(fx.fx_rate).toBe(1.2)
+  })
+})
+
+describe('splitBaseCurrencyAmount', () => {
+  it('converts a split amount with the resolved rate', () => {
+    expect(splitBaseCurrencyAmount(50, { fx_rate: 0.5, fx_rate_date: '2026-07-01', base_currency_amount: 50, rate_source: 'frankfurter' })).toBe(25)
+  })
+  it('null when no rate resolved', () => {
+    expect(splitBaseCurrencyAmount(50, { fx_rate: null, fx_rate_date: null, base_currency_amount: null, rate_source: null })).toBeNull()
+  })
+})

--- a/src/lib/fx/resolveExpenseFxFields.ts
+++ b/src/lib/fx/resolveExpenseFxFields.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared FX-field resolution for every client-side expense INSERT/UPDATE
+ * path (wizard, quick capture, chat-proposal apply). Fixes the money-path
+ * bug where the auto-fetched rate shown in the ReviewStep preview was never
+ * persisted: `fx_rate` stayed null unless the user typed a manual override,
+ * so computeBalances excluded every foreign-currency expense from the math.
+ *
+ * Rules:
+ *   - Same currency as the trip base -> all-null fields (balances treats
+ *     same-currency as rate 1 without needing a stored rate).
+ *   - Manual override -> rate_source 'manual', base_currency_amount derived
+ *     from it (fx_rate_date stays null: there's no market date for it).
+ *   - Otherwise -> best-effort fetchRate(); on failure everything stays
+ *     null (previous behavior: the expense saves, balances flag it as
+ *     missing a rate, the UI keeps warning). NEVER throws.
+ */
+import { fetchRate } from './fetchRate'
+
+export interface ExpenseFxFields {
+  fx_rate: number | null
+  fx_rate_date: string | null
+  base_currency_amount: number | null
+  rate_source: string | null
+}
+
+const NULL_FX: ExpenseFxFields = { fx_rate: null, fx_rate_date: null, base_currency_amount: null, rate_source: null }
+
+export async function resolveExpenseFxFields(params: {
+  amountMajor: number
+  currency: string
+  baseCurrency: string
+  /** YYYY-MM-DD */
+  paymentDate: string
+  /** Parsed manual override rate, if the user entered one. */
+  manualRate?: number | null
+  /** YYYY-MM-DD, injectable for tests; defaults to today. */
+  today?: string
+}): Promise<ExpenseFxFields> {
+  const { amountMajor, currency, baseCurrency, paymentDate, manualRate } = params
+  if (currency === baseCurrency) return { ...NULL_FX }
+
+  if (manualRate != null && manualRate > 0) {
+    return {
+      fx_rate: manualRate,
+      fx_rate_date: null,
+      base_currency_amount: amountMajor * manualRate,
+      rate_source: 'manual',
+    }
+  }
+
+  try {
+    const today = params.today ?? new Date().toISOString().slice(0, 10)
+    const result = await fetchRate(paymentDate, currency, baseCurrency, today)
+    if (!result) return { ...NULL_FX }
+    return {
+      fx_rate: result.rate,
+      fx_rate_date: result.date,
+      base_currency_amount: amountMajor * result.rate,
+      rate_source: result.source,
+    }
+  } catch {
+    // Best-effort only -- a rate-fetch hiccup must never block saving the
+    // expense itself (the balances screen surfaces the missing rate).
+    return { ...NULL_FX }
+  }
+}
+
+/** Per-split base_currency_amount for a resolved rate (null when no rate). */
+export function splitBaseCurrencyAmount(splitAmountMajor: number, fx: ExpenseFxFields): number | null {
+  return fx.fx_rate != null ? splitAmountMajor * fx.fx_rate : null
+}

--- a/src/lib/queries/useExpenses.mutations.test.ts
+++ b/src/lib/queries/useExpenses.mutations.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Money-path safety tests for the expense mutation hooks: a splits-insert
+ * failure must never leave an orphaned expense (broken zero-sum), and the
+ * edit path must never delete existing splits before the replacement rows
+ * are safely written.
+ *
+ * react-query's useMutation is mocked to hand back its config so the
+ * mutationFn can be exercised directly (node environment, no renderHook).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: (opts: unknown) => opts,
+  useQuery: (opts: unknown) => opts,
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+vi.mock('../reportError', () => ({ reportError: vi.fn() }))
+
+interface TableBehavior {
+  insertError?: { message: string } | null
+  upsertError?: { message: string } | null
+  updateError?: { message: string } | null
+  deleteError?: { message: string } | null
+  insertReturns?: unknown
+}
+
+const behaviors = new Map<string, TableBehavior>()
+const calls: Array<{ table: string; op: string; payload?: unknown }> = []
+
+vi.mock('../supabase', () => ({
+  supabase: {
+    from: (table: string) => {
+      const b = () => behaviors.get(table) ?? {}
+      return {
+        insert: (payload: unknown) => {
+          calls.push({ table, op: 'insert', payload })
+          const result = { data: null, error: b().insertError ?? null }
+          return {
+            ...Promise.resolve(result),
+            then: (fn: (r: typeof result) => unknown) => Promise.resolve(result).then(fn),
+            select: () => ({
+              single: async () => ({ data: b().insertReturns ?? null, error: b().insertError ?? null }),
+            }),
+          }
+        },
+        upsert: async (payload: unknown) => {
+          calls.push({ table, op: 'upsert', payload })
+          return { error: b().upsertError ?? null }
+        },
+        update: (payload: unknown) => ({
+          eq: async () => {
+            calls.push({ table, op: 'update', payload })
+            return { error: b().updateError ?? null }
+          },
+        }),
+        delete: () => ({
+          eq: () => {
+            calls.push({ table, op: 'delete' })
+            const result = Promise.resolve({ error: b().deleteError ?? null })
+            return Object.assign(result, {
+              in: async () => ({ error: b().deleteError ?? null }),
+            })
+          },
+        }),
+      }
+    },
+  },
+}))
+
+import { useCreateExpense, useUpdateExpense, type SplitRow } from './useExpenses'
+import { reportError } from '../reportError'
+
+type MutationConfig<TVars> = { mutationFn: (vars: TVars) => Promise<unknown> }
+
+const splits: SplitRow[] = [
+  { user_id: 'alice', amount: 50, split_type: 'equal' },
+  { user_id: 'bob', amount: 50, split_type: 'equal' },
+]
+
+beforeEach(() => {
+  behaviors.clear()
+  calls.length = 0
+  vi.mocked(reportError).mockClear()
+})
+
+describe('useCreateExpense rollback on splits failure', () => {
+  it('deletes the just-created expense and rethrows when splits insert fails', async () => {
+    behaviors.set('expenses', { insertReturns: { id: 'exp-1' } })
+    behaviors.set('expense_splits', { insertError: { message: 'splits boom' } })
+
+    const hook = useCreateExpense('trip-1') as unknown as MutationConfig<{ expense: object; splits: SplitRow[] }>
+    await expect(hook.mutationFn({ expense: { description: 'Dinner' }, splits })).rejects.toEqual({ message: 'splits boom' })
+
+    expect(calls.some((c) => c.table === 'expenses' && c.op === 'delete')).toBe(true)
+  })
+
+  it('reports (but still rethrows original error) when the rollback delete itself fails', async () => {
+    behaviors.set('expenses', { insertReturns: { id: 'exp-1' }, deleteError: { message: 'delete boom' } })
+    behaviors.set('expense_splits', { insertError: { message: 'splits boom' } })
+
+    const hook = useCreateExpense('trip-1') as unknown as MutationConfig<{ expense: object; splits: SplitRow[] }>
+    await expect(hook.mutationFn({ expense: { description: 'Dinner' }, splits })).rejects.toEqual({ message: 'splits boom' })
+    expect(reportError).toHaveBeenCalledWith({ message: 'delete boom' }, 'useCreateExpense.rollback')
+  })
+
+  it('does not delete anything on success', async () => {
+    behaviors.set('expenses', { insertReturns: { id: 'exp-1' } })
+    const hook = useCreateExpense('trip-1') as unknown as MutationConfig<{ expense: object; splits: SplitRow[] }>
+    const created = await hook.mutationFn({ expense: { description: 'Dinner' }, splits })
+    expect(created).toEqual({ id: 'exp-1' })
+    expect(calls.some((c) => c.op === 'delete')).toBe(false)
+  })
+})
+
+describe('useUpdateExpense split write ordering', () => {
+  const vars = {
+    expenseId: 'exp-1',
+    expense: { description: 'Dinner v2' },
+    splits,
+    removedUserIds: ['charlie'],
+  }
+
+  it('upserts the new splits BEFORE deleting removed participants (no window with missing rows)', async () => {
+    const hook = useUpdateExpense('trip-1') as unknown as MutationConfig<typeof vars>
+    await hook.mutationFn(vars)
+
+    const upsertIndex = calls.findIndex((c) => c.table === 'expense_splits' && c.op === 'upsert')
+    const deleteIndex = calls.findIndex((c) => c.table === 'expense_splits' && c.op === 'delete')
+    expect(upsertIndex).toBeGreaterThanOrEqual(0)
+    expect(deleteIndex).toBeGreaterThanOrEqual(0)
+    expect(upsertIndex).toBeLessThan(deleteIndex)
+  })
+
+  it('an upsert failure aborts before any splits are deleted (old rows stay intact)', async () => {
+    behaviors.set('expense_splits', { upsertError: { message: 'upsert boom' } })
+    const hook = useUpdateExpense('trip-1') as unknown as MutationConfig<typeof vars>
+    await expect(hook.mutationFn(vars)).rejects.toEqual({ message: 'upsert boom' })
+    expect(calls.some((c) => c.table === 'expense_splits' && c.op === 'delete')).toBe(false)
+  })
+
+  it('skipSplits touches no split rows at all', async () => {
+    const hook = useUpdateExpense('trip-1') as unknown as MutationConfig<{ expenseId: string; expense: object; skipSplits: boolean }>
+    await hook.mutationFn({ expenseId: 'exp-1', expense: {}, skipSplits: true })
+    expect(calls.filter((c) => c.table === 'expense_splits')).toEqual([])
+  })
+})

--- a/src/lib/queries/useExpenses.ts
+++ b/src/lib/queries/useExpenses.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase'
+import { reportError } from '../reportError'
 import { Expense, ExpenseSplit, ExpenseInsert, ExpenseUpdate, User } from '../../types'
 import { Tables, TablesInsert } from '../../types/database.types'
 import { queryKeys } from './queryKeys'
@@ -195,7 +196,14 @@ export function useCreateExpense(tripId: string) {
       if (splits.length > 0) {
         const rows: TablesInsert<'expense_splits'>[] = splits.map((s) => ({ expense_id: expenseData.id, ...s }))
         const { error: splitsError } = await supabase.from('expense_splits').insert(rows)
-        if (splitsError) throw splitsError
+        if (splitsError) {
+          // Roll back the just-created expense so a splits failure can't
+          // leave an orphaned expense corrupting zero-sum balances (mirrors
+          // applyProposal's create_expense_draft rollback).
+          const { error: rollbackError } = await supabase.from('expenses').delete().eq('id', expenseData.id)
+          if (rollbackError) reportError(rollbackError, 'useCreateExpense.rollback')
+          throw splitsError
+        }
       }
 
       return expenseData
@@ -232,6 +240,21 @@ export function useUpdateExpense(tripId: string) {
 
       if (skipSplits) return
 
+      // Upsert the current splits BEFORE deleting removed participants'
+      // rows: if the upsert fails, the previous splits are still intact
+      // (delete-first left the expense with missing rows -- broken zero-sum
+      // -- whenever the subsequent upsert failed). If the later delete
+      // fails, the removed participants' old rows temporarily remain and
+      // the thrown error prompts a retry -- an over-complete split set is
+      // recoverable, an orphaned/partial one silently corrupts balances.
+      if (splits && splits.length > 0) {
+        const rows: TablesInsert<'expense_splits'>[] = splits.map((s) => ({ expense_id: expenseId, ...s }))
+        const { error: splitsError } = await supabase
+          .from('expense_splits')
+          .upsert(rows, { onConflict: 'expense_id,user_id' })
+        if (splitsError) throw splitsError
+      }
+
       if (removedUserIds && removedUserIds.length > 0) {
         const { error: delError } = await supabase
           .from('expense_splits')
@@ -239,14 +262,6 @@ export function useUpdateExpense(tripId: string) {
           .eq('expense_id', expenseId)
           .in('user_id', removedUserIds)
         if (delError) throw delError
-      }
-
-      if (splits && splits.length > 0) {
-        const rows: TablesInsert<'expense_splits'>[] = splits.map((s) => ({ expense_id: expenseId, ...s }))
-        const { error: splitsError } = await supabase
-          .from('expense_splits')
-          .upsert(rows, { onConflict: 'expense_id,user_id' })
-        if (splitsError) throw splitsError
       }
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.expenses(tripId) }),

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -354,6 +354,18 @@ verify_jwt = true
 import_map = "./functions/trip-chat/deno.json"
 entrypoint = "./functions/trip-chat/index.ts"
 
+[functions.refresh-fx-rates]
+enabled = true
+verify_jwt = true
+import_map = "./functions/refresh-fx-rates/deno.json"
+entrypoint = "./functions/refresh-fx-rates/index.ts"
+
+[functions.auto-chase]
+enabled = true
+verify_jwt = true
+import_map = "./functions/auto-chase/deno.json"
+entrypoint = "./functions/auto-chase/index.ts"
+
 [functions.parse-receipt]
 enabled = true
 verify_jwt = true

--- a/supabase/migrations/20260718100000_restrict_users_payment_details.sql
+++ b/supabase/migrations/20260718100000_restrict_users_payment_details.sql
@@ -1,0 +1,106 @@
+-- Restrict SELECT on public.users (audit M-1): the table previously carried
+-- an open `USING (true)` SELECT policy, which exposed payment_details
+-- (bank / PayNow / Wise handles) to every authenticated session regardless
+-- of whether the caller had any relationship to the row's owner.
+--
+-- The app's legitimate read paths are:
+--   (a) self  -- ProfileModal, useCurrentUserRow, finalizeSignup read/update
+--       the caller's own row;
+--   (b) trip co-participants -- the participants join in useTrip.ts embeds
+--       users(*) including payment_details, and SettleUpTab shows the
+--       payee's payment rails to whoever owes them (both are always in the
+--       same trip);
+--   (c) admins -- AdminUsersTab (Dashboard) lists all users.
+--
+-- So the new policy is: self OR shares-a-trip OR admin. Both conditions
+-- that would otherwise re-query RLS-protected tables go through
+-- SECURITY DEFINER helpers with a pinned search_path, following the
+-- is_trip_participant pattern -- a plain EXISTS in a users policy that
+-- itself reads public.users (admin check) or trip_participants (whose own
+-- policies read users) is exactly the recursion shape that has bitten this
+-- schema before.
+--
+-- The base policies predate version control, so we do not assume policy
+-- names: every existing SELECT policy on public.users is dropped by a
+-- catalog-driven DO block before the replacement is created. UPDATE /
+-- INSERT / DELETE policies are left untouched.
+
+-- ---------------------------------------------------------------------------
+-- 1. Helpers (SECURITY DEFINER so they bypass RLS and cannot recurse).
+-- ---------------------------------------------------------------------------
+
+-- True when the caller's own users row has role = 'admin'. SECURITY DEFINER
+-- is what makes this safe to call from a policy ON public.users itself.
+CREATE OR REPLACE FUNCTION public.is_admin(p_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.users
+    WHERE id = p_user_id AND role = 'admin'::public.user_role
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_admin(uuid) IS 'SECURITY DEFINER admin check, safe to use inside policies on public.users without RLS recursion.';
+
+-- True when the caller (auth.uid()) shares at least one trip with
+-- p_other_user. Used to let co-participants read each other''s profile row
+-- (display fields + payment_details for settle-up).
+CREATE OR REPLACE FUNCTION public.shares_trip_with(p_other_user uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.trip_participants mine
+    JOIN public.trip_participants theirs
+      ON theirs.trip_id = mine.trip_id
+    WHERE mine.user_id = auth.uid()
+      AND theirs.user_id = p_other_user
+  );
+$$;
+
+COMMENT ON FUNCTION public.shares_trip_with(uuid) IS 'SECURITY DEFINER: does the current user share any trip with p_other_user? Backs the users SELECT policy (audit M-1).';
+
+-- Policy helpers only; no reason for direct anon access.
+REVOKE ALL ON FUNCTION public.is_admin(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.shares_trip_with(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.is_admin(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.shares_trip_with(uuid) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. Drop every existing SELECT policy on public.users (names unknown --
+--    the base schema predates version control), then install the scoped one.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'users' AND cmd = 'SELECT'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.users', pol.policyname);
+  END LOOP;
+END;
+$$;
+
+-- TO authenticated: anon sessions get no SELECT path at all (signup-time
+-- code goes through SECURITY DEFINER RPCs / the handle_new_user trigger,
+-- neither of which needs an anon policy).
+CREATE POLICY "Users readable by self, trip co-participants, admins"
+  ON public.users
+  FOR SELECT
+  TO authenticated
+  USING (
+    id = auth.uid()
+    OR public.shares_trip_with(id)
+    OR public.is_admin(auth.uid())
+  );

--- a/supabase/migrations/20260718110000_invitation_attempts_hardening.sql
+++ b/supabase/migrations/20260718110000_invitation_attempts_hardening.sql
@@ -1,0 +1,77 @@
+-- invitation_attempts hardening (H-1 residue). Two parts:
+--
+--  1. Drop any direct INSERT policy on public.invitation_attempts. Since
+--     20260710150000_log_invitation_attempt.sql all legitimate writes go
+--     through the SECURITY DEFINER log_invitation_attempt() RPC (which
+--     bypasses RLS as table owner), so a permissive table-level INSERT
+--     policy is pure attack surface: anyone with the anon key could spam
+--     the audit log directly, with arbitrary-length payloads. Policy names
+--     predate version control, so drop is catalog-driven.
+--
+--  2. Harden log_invitation_attempt() itself:
+--       - truncate p_code to 64 chars and p_user_agent to 512 chars
+--         (truncate, not reject -- the caller treats this as
+--         fire-and-forget and must never see a new failure mode);
+--       - per-IP throttle: silently no-op once the same ip_address has
+--         logged > 20 rows in the last hour. Silent (still returns true)
+--         so the throttle is not an oracle a prober can observe.
+--
+-- IP caveat: ip_address is populated by the table's column default (the
+-- RPC never sets it), and behind PostgREST/the pooler inet_client_addr()
+-- may resolve to the pooler's address rather than the end client. If that
+-- happens the throttle degrades to a coarse global cap of ~20 logged
+-- attempts/hour, which is still an acceptable bound for a security audit
+-- log (get_recent_failed_attempts alerts on > 2 attempts per code anyway).
+-- NULL ip buckets together via IS NOT DISTINCT FROM.
+
+-- ---------------------------------------------------------------------------
+-- 1. No direct INSERT path (defense-in-depth mirror of client_errors).
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'invitation_attempts'
+      AND cmd = 'INSERT'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.invitation_attempts', pol.policyname);
+  END LOOP;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Length caps + per-IP throttle in the RPC.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.log_invitation_attempt(p_code text, p_success boolean, p_user_agent text)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_ip inet := inet_client_addr();
+  v_recent bigint;
+BEGIN
+  -- Throttle: > 20 rows from this ip_address in the last hour -> silent
+  -- no-op. Returning true keeps the response indistinguishable from a
+  -- logged attempt (no oracle) and keeps the client fire-and-forget.
+  SELECT count(*) INTO v_recent
+  FROM public.invitation_attempts
+  WHERE ip_address IS NOT DISTINCT FROM v_ip
+    AND created_at > now() - interval '1 hour';
+
+  IF v_recent > 20 THEN
+    RETURN true;
+  END IF;
+
+  INSERT INTO public.invitation_attempts (code_attempted, success, user_agent)
+  VALUES (left(p_code, 64), p_success, left(p_user_agent, 512));
+  RETURN true;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.log_invitation_attempt(text, boolean, text) TO anon, authenticated;

--- a/supabase/migrations/20260718120000_fx_rates_write_restriction.sql
+++ b/supabase/migrations/20260718120000_fx_rates_write_restriction.sql
@@ -1,0 +1,54 @@
+-- fx_rates write restriction (audit M-4 follow-up; 20260707110000 §5 only
+-- bounded the values with a CHECK, leaving the write path open).
+--
+-- Chosen design: KEEP INSERT for authenticated, DROP UPDATE (and DELETE).
+-- Rationale: the client is an active writer -- storeDbRate() in
+-- src/lib/currency.ts upserts freshly fetched frankfurter rates as the
+-- signed-in user (cache-fill), and src/lib/fx/fetchRate.ts's optional db
+-- accessor does the same. Removing INSERT entirely would silently kill the
+-- shared DB rate cache for all users. What actually matters for integrity
+-- is that an authenticated user cannot CLOBBER an existing rate other
+-- users rely on: with UPDATE dropped, a row, once written, is immutable to
+-- clients; only the service role (refresh-fx-rates edge function, which
+-- bypasses RLS) can correct or overwrite rates.
+--
+-- Client impact: storeDbRate() uses upsert(onConflict). When no row exists
+-- the INSERT succeeds as before; when a row already exists the ON CONFLICT
+-- DO UPDATE arm is now denied and the upsert errors -- storeDbRate already
+-- swallows this (logs via console.error, fire-and-forget, never throws),
+-- and the row it "failed" to write already exists, so behavior is
+-- unchanged. No src change required.
+--
+-- Policy names predate version control -> catalog-driven drops, then
+-- recreate the intended set by well-known names.
+
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT policyname, cmd
+    FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'fx_rates'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.fx_rates', pol.policyname);
+  END LOOP;
+END;
+$$;
+
+-- Reads: any signed-in user (rates are not sensitive; anon has no need).
+CREATE POLICY "Authenticated users can read fx rates"
+  ON public.fx_rates
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Cache-fill: signed-in users may add NEW rate rows (bounded by the
+-- fx_rates_rate_positive CHECK from 20260707110000). No UPDATE / DELETE
+-- policy exists after this migration: existing rows are immutable to
+-- clients; corrections go through the service role, which bypasses RLS.
+CREATE POLICY "Authenticated users can insert fx rates"
+  ON public.fx_rates
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);

--- a/supabase/migrations/20260718130000_invitation_rpc_rate_limiting.sql
+++ b/supabase/migrations/20260718130000_invitation_rpc_rate_limiting.sql
@@ -1,0 +1,185 @@
+-- Rate-limit the anon-callable invitation RPCs. validate_invitation_code
+-- and get_invitation_preview (20260707110000 §3, 20260707130000) are
+-- reachable with just the anon key and previously unthrottled, so a script
+-- could brute-force / enumerate invitation codes at full REST throughput.
+--
+-- Mechanism: GLOBAL-PER-CODE lockout, not per-IP. Reasons:
+--   - log_invitation_attempt never sets invitation_attempts.ip_address
+--     (it comes from a column default), and behind PostgREST + the
+--     connection pooler inet_client_addr() typically resolves to the
+--     pooler, not the end client -- so "per IP" would collapse into one
+--     shared bucket, throttling legitimate users while doing nothing
+--     against a distributed prober. A per-code counter is attacker-cost
+--     shaped instead: each candidate code gets at most N probes per
+--     window across ALL callers, which is exactly what code enumeration
+--     needs unbounded.
+--   - It reuses the existing invitation_attempts audit table; no new
+--     counter table.
+--
+-- Crucially, failed probes are now logged SERVER-SIDE inside the RPCs
+-- themselves: previously only Signup.tsx voluntarily called
+-- log_invitation_attempt after validating, so a direct REST caller left no
+-- trail and a counter would never trip. Server-side rows carry
+-- user_agent = '[server:...]' so the Signup flow's own client-side log
+-- (which has the real user agent) remains distinguishable; the client call
+-- is kept, so one failed UI attempt now logs twice -- the threshold below
+-- is sized with that in mind.
+--
+-- Behavior when locked out: return the SAME shape as an invalid / unknown
+-- code ('not_found' from validate_invitation_code, zero rows from
+-- get_invitation_preview), so the limiter is not an oracle -- a prober
+-- cannot distinguish "code does not exist" from "code is being shielded".
+-- A real user who fat-fingers a valid code repeatedly sees "invalid code"
+-- until the 15-minute window slides; acceptable, and the attempts remain
+-- visible to admins via get_recent_failed_attempts.
+--
+-- Threshold: > 30 FAILED attempts against the same normalized code in the
+-- last 15 minutes. Successful validations don't count, so a shared /join
+-- link opened by a whole group does not lock the code out.
+
+-- ---------------------------------------------------------------------------
+-- Shared helpers (SECURITY DEFINER: invitation_attempts has no anon
+-- SELECT/INSERT policy, by design -- see 20260718110000).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.invitation_code_locked_out(p_code text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT count(*) > 30
+  FROM public.invitation_attempts
+  WHERE upper(code_attempted) = upper(left(p_code, 64))
+    AND success = false
+    AND created_at > now() - interval '15 minutes';
+$$;
+
+COMMENT ON FUNCTION public.invitation_code_locked_out(text) IS 'Global-per-code brute-force lockout for the anon invitation RPCs (> 30 failed attempts / 15 min). Per-IP was rejected because the pooler masks client IPs.';
+
+-- Server-side probe log: mirrors log_invitation_attempt's caps but tags the
+-- row so admin tooling can tell RPC-internal rows from Signup's own logging.
+CREATE OR REPLACE FUNCTION public.log_invitation_probe(p_code text, p_success boolean, p_source text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  INSERT INTO public.invitation_attempts (code_attempted, success, user_agent)
+  VALUES (left(p_code, 64), p_success, left('[server:' || p_source || ']', 512));
+EXCEPTION WHEN OTHERS THEN
+  -- Logging must never break code validation for real users.
+  NULL;
+END;
+$$;
+
+-- Internal helpers for the two RPCs below; no direct client callers.
+REVOKE ALL ON FUNCTION public.invitation_code_locked_out(text) FROM anon;
+REVOKE ALL ON FUNCTION public.invitation_code_locked_out(text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.log_invitation_probe(text, boolean, text) FROM anon;
+REVOKE ALL ON FUNCTION public.log_invitation_probe(text, boolean, text) FROM authenticated;
+
+-- ---------------------------------------------------------------------------
+-- validate_invitation_code: unchanged semantics (matches 20260707110000 §3)
+-- plus (a) server-side logging of failed lookups, (b) the lockout
+-- short-circuit, indistinguishable from 'not_found'.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.validate_invitation_code(p_code text)
+RETURNS TABLE (
+  invitation_id uuid,
+  is_valid boolean,
+  reason text,
+  trip_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_inv public.invitations%ROWTYPE;
+BEGIN
+  IF public.invitation_code_locked_out(p_code) THEN
+    -- Do NOT log while locked out: otherwise the attacker's own probes
+    -- keep the window saturated forever AND the table grows unboundedly.
+    RETURN QUERY SELECT NULL::uuid, false, 'not_found'::text, NULL::uuid;
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_inv FROM public.invitations WHERE code = upper(p_code);
+
+  IF NOT FOUND THEN
+    PERFORM public.log_invitation_probe(p_code, false, 'validate_invitation_code');
+    RETURN QUERY SELECT NULL::uuid, false, 'not_found'::text, NULL::uuid;
+  ELSIF v_inv.used_by IS NOT NULL THEN
+    PERFORM public.log_invitation_probe(p_code, false, 'validate_invitation_code');
+    RETURN QUERY SELECT v_inv.id, false, 'already_used'::text, NULL::uuid;
+  ELSIF v_inv.expires_at IS NOT NULL AND v_inv.expires_at < now() THEN
+    PERFORM public.log_invitation_probe(p_code, false, 'validate_invitation_code');
+    RETURN QUERY SELECT v_inv.id, false, 'expired'::text, NULL::uuid;
+  ELSE
+    RETURN QUERY SELECT v_inv.id, true, 'valid'::text, v_inv.trip_id;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.validate_invitation_code(text) TO anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- get_invitation_preview: same column list / filters as 20260707130000,
+-- now plpgsql (was SQL/STABLE) so it can log failed probes and share the
+-- lockout. Locked-out codes yield zero rows -- exactly like an unknown,
+-- used, expired, or tripless code.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_invitation_preview(p_code text)
+RETURNS TABLE (
+  trip_name text,
+  location text,
+  start_date date,
+  end_date date,
+  accent_seed text,
+  estimated_cost numeric,
+  cost_currency text,
+  confirmed_count int,
+  organizer_first_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF public.invitation_code_locked_out(p_code) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    t.name                                   AS trip_name,
+    t.location                               AS location,
+    t.start_date                             AS start_date,
+    t.end_date                               AS end_date,
+    t.id::text                               AS accent_seed,
+    t.estimated_accommodation_cost::numeric  AS estimated_cost,
+    t.accommodation_cost_currency            AS cost_currency,
+    (
+      SELECT count(*)::int
+      FROM public.trip_participants tp
+      WHERE tp.trip_id = t.id
+        AND tp.confirmation_status = 'confirmed'
+    )                                        AS confirmed_count,
+    COALESCE(u.first_name, split_part(u.full_name, ' ', 1)) AS organizer_first_name
+  FROM public.invitations i
+  JOIN public.trips t ON t.id = i.trip_id
+  LEFT JOIN public.users u ON u.id = t.created_by
+  WHERE i.code = upper(p_code)
+    AND i.used_by IS NULL
+    AND (i.expires_at IS NULL OR i.expires_at > now())
+    AND i.trip_id IS NOT NULL;
+
+  IF NOT FOUND THEN
+    PERFORM public.log_invitation_probe(p_code, false, 'get_invitation_preview');
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_invitation_preview(text) TO anon, authenticated;

--- a/supabase/migrations/20260718140000_replica_identity_full_for_realtime.sql
+++ b/supabase/migrations/20260718140000_replica_identity_full_for_realtime.sql
@@ -1,0 +1,57 @@
+-- Realtime DELETE fix for trip-scoped subscriptions.
+--
+-- src/lib/queries/useTripRealtime.ts subscribes each table in
+-- DIRECT_TRIP_TABLES with a `trip_id=eq.${tripId}` postgres_changes
+-- filter. Realtime evaluates that filter against the event payload, and
+-- for DELETE events the payload only contains the table's REPLICA
+-- IDENTITY columns -- by default just the primary key. trip_id is
+-- therefore absent, the filter never matches, and deletes silently never
+-- reach clients: a deleted expense/settlement/etc. stays on every other
+-- participant's screen until a manual refetch.
+--
+-- Fix: REPLICA IDENTITY FULL on exactly the DIRECT_TRIP_TABLES list, so
+-- DELETE payloads carry the whole old row (including trip_id) and the
+-- filter matches. (INDIRECT_TABLES in the same file subscribe unfiltered,
+-- so they are unaffected and are deliberately NOT changed here.)
+--
+-- Tradeoff, acknowledged: REPLICA IDENTITY FULL writes the entire old row
+-- to WAL on every UPDATE/DELETE instead of just the PK (write
+-- amplification). These are small, low-churn, per-trip tables (tens to
+-- low hundreds of rows each), so the overhead is negligible and worth
+-- correct realtime deletes.
+--
+-- Defensive: table list mirrors the frontend constant at time of writing;
+-- each is guarded so a renamed/dropped table doesn't fail the migration.
+
+DO $$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    -- keep in sync with DIRECT_TRIP_TABLES in src/lib/queries/useTripRealtime.ts
+    'trips',
+    'trip_participants',
+    'planning_sections',
+    'expenses',
+    'settlements',
+    'settlement_carryovers',
+    'trip_timeline_events',
+    'trip_notes',
+    'bookings',
+    'places',
+    'activity_feed',
+    'ai_proposals',
+    'trip_checklists',
+    'notifications',
+    'trip_chat_messages',
+    'reactions'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I REPLICA IDENTITY FULL', t);
+    ELSE
+      RAISE NOTICE 'replica identity: table public.% not found, skipping', t;
+    END IF;
+  END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260718150000_function_hygiene.sql
+++ b/supabase/migrations/20260718150000_function_hygiene.sql
@@ -1,0 +1,106 @@
+-- Function hygiene from the Supabase security advisor:
+--
+--  1. Pin search_path (= public, pg_temp) on the flagged functions. Their
+--     bodies live only on the remote DB (they predate version control), so
+--     ALTER FUNCTION -- not CREATE OR REPLACE -- is the correct tool: it
+--     changes only the proconfig, never the body. Signatures are likewise
+--     unknown, so we resolve every overload of each name from pg_proc and
+--     ALTER by regprocedure; missing names are skipped with a NOTICE.
+--
+--  2. REVOKE EXECUTE from anon on SECURITY DEFINER / privileged RPCs that
+--     have no legitimate pre-auth caller. Verified against the frontend:
+--     the only RPCs the signup flow calls BEFORE a session exists are
+--     validate_invitation_code, get_invitation_preview and
+--     log_invitation_attempt (Signup.tsx code-validation step + /join
+--     teaser + reportError's log_client_error -- see below), so those keep
+--     anon. mark_invitation_used / assign_user_to_trip run inside
+--     finalizeAccount()/finalizeSignup.ts, which only executes "once we
+--     have an authenticated user", so authenticated suffices.
+--     handle_new_user-style auth triggers run as the table owner and need
+--     no client grant at all.
+--
+--     log_client_error is listed by the advisor but KEPT for anon
+--     deliberately: src/lib/reportError.ts must be able to report crashes
+--     from the login/signup/join pages, which run pre-auth. Revoking anon
+--     there would blind us to exactly the incident class (2026-07-10,
+--     signup-flow failures) the telemetry was built for.
+
+-- ---------------------------------------------------------------------------
+-- 1. Pin search_path on all overloads of each flagged function name.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  fname text;
+  fn record;
+  found boolean;
+BEGIN
+  FOREACH fname IN ARRAY ARRAY[
+    'check_all_items_claimed',
+    'update_trip_participants_updated_at',
+    'auto_update_expense_status',
+    'get_confirmation_summary',
+    'check_conditions_met',
+    'get_confirmed_count',
+    'enforce_capacity_limit',
+    'notify_conditional_users',
+    'clear_confirmed_timestamp',
+    'create_trip_with_participant',
+    'can_view_trip',
+    'is_trip_participant',
+    'is_trip_organizer',
+    'guard_immutable_keys'
+  ]
+  LOOP
+    found := false;
+    FOR fn IN
+      SELECT p.oid::regprocedure AS sig
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = fname
+    LOOP
+      EXECUTE format('ALTER FUNCTION %s SET search_path = public, pg_temp', fn.sig);
+      found := true;
+    END LOOP;
+    IF NOT found THEN
+      RAISE NOTICE 'search_path pin: no function public.%() found, skipping', fname;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Revoke anon EXECUTE where there is no pre-auth caller.
+--    (Grants for authenticated are left exactly as they are.)
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  fname text;
+  fn record;
+BEGIN
+  FOREACH fname IN ARRAY ARRAY[
+    'create_invitation',
+    'create_trip_with_participant',
+    'mark_invitation_used',
+    'assign_user_to_trip',
+    'consume_rate_limit',
+    'get_confirmation_summary',
+    'get_confirmed_count',
+    'check_all_items_claimed',
+    'cleanup_expired_invitations',
+    'get_recent_failed_attempts'
+    -- NOT log_client_error: pre-auth pages report errors through it.
+    -- NOT validate_invitation_code / get_invitation_preview /
+    --     log_invitation_attempt: the pre-auth signup/join path needs them.
+  ]
+  LOOP
+    FOR fn IN
+      SELECT p.oid::regprocedure AS sig
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = fname
+    LOOP
+      EXECUTE format('REVOKE ALL ON FUNCTION %s FROM anon', fn.sig);
+    END LOOP;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
## Bug fixes
- **Signup profile loss** (root cause of the emma.nie2018 null-name incident): OTP signup now passes profile metadata to `signInWithOtp`; `finalizeAccount` fails loud with retry + telemetry via a shared `finalizeSignup` module; magic-link signups reconcile from a stored pending payload; invitation is re-validated before account creation.
- **FX rates never persisted**: auto-fetched rates are now saved on expenses and splits at save time (wizard, quick capture, AI proposal apply), so foreign-currency expenses count in balances.
- **Expense integrity**: `useCreateExpense` rolls back the orphan expense if splits insert fails; `useUpdateExpense` upserts before deleting; proposal-apply rollback failures are reported.
- **Settle-up simplify toggle** was a no-op; direct pairwise mode now implemented via `computePairwiseBreakdown`.

## Security
Six migrations (already applied to prod — the DB is ahead of this code, and the deployed frontend is compatible): users/payment_details SELECT restriction, invitation_attempts hardening, fx_rates client immutability, per-code invitation brute-force lockout, REPLICA IDENTITY FULL for realtime DELETEs, function search_path/grant hygiene. Plus `verify_jwt` config blocks for the two cron edge functions.

## Deps
react-router-dom 7.9.5 → 7.18.1; `npm audit` now reports 0 vulnerabilities.

## Verification
647/647 unit tests, tsc, eslint (0 errors), production build, contract-drift and z-index checks all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)